### PR TITLE
[retries] Allow specifying status codes to retry on

### DIFF
--- a/src/service/middleware/retry.rs
+++ b/src/service/middleware/retry.rs
@@ -45,7 +45,7 @@ impl<B> Policy<Request<OctoBody>, Response<B>, Error> for RetryConfig {
             },
             RetryConfig::SimpleWithStatuses(count, statuses) => match result {
                 Ok(response) => {
-                    if response.status().is_server_error() || statuses.contains(*response.status()) {
+                    if response.status().is_server_error() || statuses.contains(&response.status().as_u16()) {
                         if *count > 0 {
                             Some(future::ready(RetryConfig::SimpleWithStatuses(count - 1, statuses)))
                         } else {


### PR DESCRIPTION
Octocrab's retry logic is... less than ideal. We need to handle both 401
and 429 statuses, so just allow an array of status codes to be checked
against. If one wanted this to be more generic, they could thread some
extra types and such through, but that feels like a bigger thing to do
than what I have here.
