### PR TITLE
[octocrab] Allow committer to be Author *or* GitUser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octocrab"
-version = "0.39.0"
+version = "0.39.1"
 resolver = "2"
 authors = ["XAMPPRocky <xampprocky@gmail.com>"]
 edition = "2018"

--- a/src/models/commits.rs
+++ b/src/models/commits.rs
@@ -61,9 +61,9 @@ pub struct CommitComparison {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitElement {
-    pub author: Option<GitUser>,
+    pub author: Option<CommitAuthor>,
     pub comment_count: i64,
-    pub committer: Option<GitUser>,
+    pub committer: Option<CommitAuthor>,
     pub message: String,
     pub tree: Tree,
     pub url: String,
@@ -113,13 +113,23 @@ pub struct CommitStats {
     pub total: Option<i64>,
 }
 
+/// The 'author' and 'committer' fields can either be
+/// a full set of Author details *or* sometimes, if done
+/// by a bot, etc, just have the git information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum CommitAuthor {
+    Author(Author),
+    GitUser(GitUser),
+}
+
 /// Commit
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Commit {
-    pub author: Option<Author>,
+    pub author: Option<GitUser>,
     pub comments_url: String,
     pub commit: CommitElement,
-    pub committer: Option<Author>,
+    pub committer: Option<GitUser>,
     pub files: Option<Vec<repos::DiffEntry>>,
     pub html_url: String,
     pub node_id: String,


### PR DESCRIPTION
In some cases it seems the Compare Commits endpoint (`/repos/{owner}/{repo}/compare/{base}...{head}`) will return *either* a full Author object for committer and author of each commit *or* just the name, email, etc that are in GitUser. This appears to be the case when e.g. a bot does the commit that github cannot tie to a user specifically? In any case, this change allows us to deserialize that commit comparison endpoint's results while also allowing us to get full information if it's available.