### PR TITLE
[octocrab] Use CommitAuthor instead of GitUser/Author in Commit

### DIFF
--- a/src/models/commits.rs
+++ b/src/models/commits.rs
@@ -126,10 +126,10 @@ pub enum CommitAuthor {
 /// Commit
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Commit {
-    pub author: Option<GitUser>,
+    pub author: Option<CommitAuthor>,
     pub comments_url: String,
     pub commit: CommitElement,
-    pub committer: Option<GitUser>,
+    pub committer: Option<CommitAuthor>,
     pub files: Option<Vec<repos::DiffEntry>>,
     pub html_url: String,
     pub node_id: String,


### PR DESCRIPTION
In https://github.com/discord/octocrab/pull/4 , this was changed from Author -> GitUser. Prefer to allow both of these so we can pull user logins for commits without having to guess from their email.