### PR TITLE
[octocrab] Expose get_links from page module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ mod api;
 mod body;
 mod error;
 mod from_response;
-mod page;
+pub mod page;
 
 pub mod auth;
 pub mod etag;

--- a/src/page.rs
+++ b/src/page.rs
@@ -226,14 +226,14 @@ impl<T: serde::de::DeserializeOwned> crate::FromResponse for Page<T> {
     }
 }
 
-struct HeaderLinks {
-    next: Option<Uri>,
-    prev: Option<Uri>,
-    first: Option<Uri>,
-    last: Option<Uri>,
+pub struct HeaderLinks {
+    pub next: Option<Uri>,
+    pub prev: Option<Uri>,
+    pub first: Option<Uri>,
+    pub last: Option<Uri>,
 }
 
-fn get_links(headers: &http::header::HeaderMap) -> crate::Result<HeaderLinks> {
+pub fn get_links(headers: &http::header::HeaderMap) -> crate::Result<HeaderLinks> {
     let mut first = None;
     let mut prev = None;
     let mut next = None;


### PR DESCRIPTION
The commit compare endpoint does not conform to how octocrab expects paginated response bodies to be shaped. So, we need to expose a way to get the pagination headers from the response and manually do a little pagination ourselves.