### PR TITLE
[octocrab] Make some fields optional...

### DIFF
--- a/src/models/commits.rs
+++ b/src/models/commits.rs
@@ -142,8 +142,8 @@ pub struct Commit {
     pub node_id: String,
     pub parents: Vec<CommitParent>,
     /// Minimal Repository
-    pub repository: MinimalRepository,
-    pub score: f64,
+    pub repository: Option<MinimalRepository>,
+    pub score: Option<f64>,
     pub sha: String,
     pub text_matches: Option<Vec<SearchResultTextMatch>>,
     pub url: Url,


### PR DESCRIPTION
It looks like the CommitComparison's base_commit object uses Commit for its type, which as of recently(ish), requires repository and score. These however are not returned in the commit object from github (https://docs.github.com/en/rest/commits/commits?apiVersion=2026-03-10 seems to not have a repository object, even an optional one, in the base_commit). Just make those fields optional for now.