### PR TITLE
[octocrab] Make sure that GET requests apply retry policy

### DIFF
--- a/src/service/middleware/retry.rs
+++ b/src/service/middleware/retry.rs
@@ -138,7 +138,12 @@ impl<B> Policy<Request<OctoBody>, Response<B>, Error> for RetryConfig {
         match self {
             RetryConfig::None => None,
             _ => {
-                let body = req.body().try_clone()?;
+                // This returns none if the body is empty. Just return an empty body
+                // instead so that we retry GET requests.
+                let body = match req.body().try_clone() {
+                    Some(b) => b,
+                    None => OctoBody::empty()
+                };
 
                 // `Request` can't be cloned
                 let mut new_req = Request::builder()


### PR DESCRIPTION
Applying https://github.com/XAMPPRocky/octocrab/issues/868 to make sure we actually use the retry policy on GET requests.